### PR TITLE
Simplify game - remove bidding

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can play the game immediately by opening `index.html` in any modern web brow
 Fight the Landlord is played with 3 players using a 54-card deck (including 2 jokers):
 
 1. **Card Distribution**: Each player gets 17 cards, 3 cards remain as "landlord cards"
-2. **Landlord Selection**: Players bid to become the landlord
+2. **Landlord Selection**: Player 1 is automatically the landlord
 3. **Landlord Advantage**: Gets the 3 extra cards (20 total)
 4. **Victory Conditions**: 
    - Landlord wins by playing all cards first

--- a/index.html
+++ b/index.html
@@ -54,8 +54,6 @@
                     <p>Waiting for cards...</p>
                 </div>
                 <div class="game-controls">
-                    <button id="call-landlord" class="btn">Call Landlord</button>
-                    <button id="pass-landlord" class="btn">Pass</button>
                     <button id="play-cards" class="btn" disabled>Play Cards</button>
                     <button id="pass-turn" class="btn" disabled>Pass Turn</button>
                     <button id="hint" class="btn">Hint</button>


### PR DESCRIPTION
## Summary
- start each game with Player 1 as the landlord
- drop the bidding interface and related logic
- adjust controls to only show Play, Pass, and Hint
- document simplified landlord selection

## Testing
- `npm test` *(fails: could not find package.json)*