### PR TITLE
Add JPEG serving test

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ function createServer() {
       '.css': 'text/css',
       '.json': 'application/json',
       '.png': 'image/png',
-      '.jpg': 'image/jpg',
+      '.jpg': 'image/jpeg',
       '.gif': 'image/gif',
       '.svg': 'image/svg+xml',
       '.wav': 'audio/wav',

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -42,6 +42,14 @@ test('serves style.css with correct content type', async () => {
   });
 });
 
+test('serves wukong.jpg with correct content type', async () => {
+  await withServer(async port => {
+    const { status, headers } = await fetchText(port, '/images/wukong.jpg');
+    assert.strictEqual(status, 200);
+    assert.strictEqual(headers.get('content-type'), 'image/jpeg');
+  });
+});
+
 test('returns 404 for missing file', async () => {
   await withServer(async port => {
     const { status } = await fetchText(port, '/nope.txt');


### PR DESCRIPTION
## Summary
- test server serves `wukong.jpg` with image/jpeg
- fix server MIME type for `.jpg`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ec3e41f8832cabea22bcb0b5039c