### PR TITLE
Fix 404 page handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,17 +35,22 @@ function createServer() {
 
     const contentType = mimeTypes[extname] || 'application/octet-stream';
 
-    fs.readFile(filePath, (error, content) => {
-      if (error) {
-        if (error.code === 'ENOENT') {
-          fs.readFile('./404.html', (error, content) => {
+      fs.readFile(filePath, (error, content) => {
+        if (error) {
+          if (error.code === 'ENOENT') {
+          fs.readFile('./404.html', (err404, page) => {
             res.writeHead(404, { 'Content-Type': 'text/html' });
-            res.end(content, 'utf-8');
+            if (err404) {
+              // Fallback plain message when custom 404 page is missing
+              res.end('404 Not Found', 'utf-8');
+            } else {
+              res.end(page, 'utf-8');
+            }
           });
-        } else {
-          res.writeHead(500);
-          res.end('Sorry, check with the site admin for error: ' + error.code + ' ..\n');
-        }
+          } else {
+            res.writeHead(500);
+            res.end('Sorry, check with the site admin for error: ' + error.code + ' ..\n');
+          }
       } else {
         // Set proper headers including content-length
         const headers = {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -44,7 +44,8 @@ test('serves style.css with correct content type', async () => {
 
 test('returns 404 for missing file', async () => {
   await withServer(async port => {
-    const { status } = await fetchText(port, '/nope.txt');
+    const { status, text } = await fetchText(port, '/nope.txt');
     assert.strictEqual(status, 404);
+    assert.ok(text.length > 0);
   });
 });


### PR DESCRIPTION
## Summary
- handle missing `404.html` gracefully in server
- verify non-empty body in 404 test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840d9f5bb54832cbf6fc6231de814e9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for missing files by serving a custom 404 page when available, or a default "404 Not Found" message if not.
- **Tests**
  - Enhanced tests to verify that 404 responses include non-empty content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->